### PR TITLE
NDS-623: Many specs with HTTP ports are missing context 

### DIFF
--- a/clowder/clowder.json
+++ b/clowder/clowder.json
@@ -85,7 +85,8 @@
     "ports": [
         {
             "port": 9000,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "resourceLimits": {


### PR DESCRIPTION
Update all HTTP specs to include a context path of "/", where appropriate

See https://opensource.ncsa.illinois.edu/jira/browse/NDS-623